### PR TITLE
update for Julia 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 1.0
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Add FileIO.jl integration for FCS files
 ```julia
 julia> using FileIO
 
-julia> using FCSFiles
-
 julia> flowrun = load("example.fcs")
 FCS.FlowSample{Float32}
     Machine: LSRFortessa

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6
+julia 0.7
 FileIO

--- a/src/FCSFiles.jl
+++ b/src/FCSFiles.jl
@@ -8,11 +8,7 @@ include("parse.jl")
 
 export FlowSample
 
-try
-    add_format(format"FCS", "FCS", [".fcs"])
-end
-
-function FileIO.load(f::File{format"FCS"})
+function load(f::File{format"FCS"})
     open(f) do io
         offsets = parse_header(io)
 

--- a/src/type.jl
+++ b/src/type.jl
@@ -1,4 +1,4 @@
-immutable FlowSample{T}
+struct FlowSample{T}
     data::Dict{String, Vector{T}}
     params::Dict{String, String}
 end
@@ -38,6 +38,5 @@ Base.haskey(f::FlowSample, x) = haskey(f.data, x)
 Base.getindex(f::FlowSample, key) = f.data[key]
 Base.keys(f::FlowSample) = keys(f.data)
 Base.values(f::FlowSample) = values(f.data)
-Base.start(iter::FlowSample) = start(iter.data)
-Base.next(iter::FlowSample, state) = next(iter.data, state)
-Base.done(iter::FlowSample, state) = done(iter.data, state)
+Base.iterate(iter::FlowSample) = Base.iterate(iter.data)
+Base.iterate(iter::FlowSample, state) = Base.iterate(iter.data, state)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using FCSFiles
 using FileIO
-using Base.Test
+using Test
 
 flowrun = load("testdata/BD-FACS-Aria-II.fcs")
 


### PR DESCRIPTION
- use new iteration protocol
- move format registration to FileIO
- update for deprecations

This requires https://github.com/JuliaIO/FileIO.jl/pull/206 since I'm moving the format registration code over there as per the docs.