### PR TITLE
Fix loading of keywords that do not begin with '$'

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -33,24 +33,25 @@ function parse_text(io, start_text::Int, end_text::Int)
     raw_btext = Array{UInt8}(undef, end_text - start_text + 1)
     read!(io, raw_btext)
     raw_text = String(raw_btext)
-    delimiter = raw_text[1]
+    # initialize iterator, save&skip the delimiter
+    delimiter, state = iterate(raw_text)
 
+    # container for the results
     text_mappings = Dict{String, String}()
-    # initialize iterator
-    iter_result = iterate(raw_text)
-    while iter_result !== nothing
-        i, state = iter_result
 
-        # found a new key, value pair
-        if i == '$'
-            # grab key and ignore escaped delimiters
-            key, state = grab_word(raw_text, state, delimiter)
-            # grab value and ignore escaped delimiters
-            value, state = grab_word(raw_text, state, delimiter)
-            # FCS keywords are case insensitive so force them uppercase
-            text_mappings["\$"*uppercase(key)] = value
+    while true
+        # grab key and ignore escaped delimiters
+        key, state = grab_word(raw_text, state, delimiter)
+
+        if isempty(key) # empty key means the iteration has ended
+            break       # (technically, empty keys are impossible in FCS3)
         end
-        iter_result = iterate(raw_text, state)
+
+        # grab value and ignore escaped delimiters
+        value, state = grab_word(raw_text, state, delimiter)
+
+        # FCS keywords are case insensitive so force everything to uppercase
+        text_mappings[uppercase(key)] = value
     end
     text_mappings
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,7 @@ using Test, HTTP
         # load the large file
         flowrun = load("testdata/testLargeFile.fcs")
         @test length(flowrun.data) == 50
-        @test length(flowrun.params) == 262
+        @test length(flowrun.params) == 268
 
         # cleanup
         rm("testdata/testLargeFile.fcs", force=true)


### PR DESCRIPTION
This is a pretty common situation -- for example, the spillover matrix is commonly labeled as "SPILL", "SPILLOVER" and only rarely as "$SPILL". Example of such data can be found eg. at http://flowrepository.org/id/FR-FCM-ZYX9 .

The test now loads several more keywords from the FCS, so I increased the number accordingly.

(cc: @laurentheirendt )