### PR TITLE
update the deprecated warning syntax

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FCSFiles"
 uuid = "d76558cf-badf-52d4-a17e-381ab0b0d937"
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -4,7 +4,7 @@ function parse_header(io)
     read!(io, rawversion)
     version = String(rawversion)
     if "$version" != "FCS3.0" && version != "FCS3.1"
-        warn("$version files are not guaranteed to work")
+        @warn "$version files are not guaranteed to work"
     end
     seek(io, 10)
     # start, end positions of TEXT, DATA, and ANALYSIS sections

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,28 @@ using FileIO
 using Test, HTTP
 
 @testset "FCSFiles test suite" begin
+
+    # test loading an FCS 2.0 file
+    @testset "Loading an FCS 2.0 file" begin
+        # download the FCS 2.0 file
+        cwd = pwd()
+        cd(cwd*"/testdata")
+        @info "Downloading FCS 2.0 file ..."
+        io = open("testFCS2.fcs", "w")
+        r = HTTP.request("GET", "https://flowrepository.org/experiments/4/fcs_files/326/download", response_stream=io)
+        close(io)
+        cd(cwd)
+        @info "Done."
+
+        # load the FCS 2.0 file
+        @test_throws ErrorException @test_warn "FSC2.0 files are not guaranteed to work" flowrun = load("testdata/testFCS2.fcs")
+
+        # cleanup
+        rm("testdata/testFCS2.fcs", force=true)
+        @info "FCS 2.0 file removed"
+    end
+
+    # test the size of the file
     @testset "SSC-A size" begin
         flowrun = load("testdata/BD-FACS-Aria-II.fcs")
 


### PR DESCRIPTION
`warn(...)` causes an undefined identifier error in newer Julia versions, use the recommended `@warn` macro instead.