### PR TITLE
move datasets over to tlnagy/fcsexamples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .ipynb_checkpoints/
 *.ipynb
 *Manifest.toml
+test/fcsexamples/

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FCSFiles"
 uuid = "d76558cf-badf-52d4-a17e-381ab0b0d937"
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,54 +2,29 @@ using FCSFiles
 using FileIO
 using Test, HTTP
 
+project_root = isfile("runtests.jl") ? abspath("..") : abspath(".")
+testdata_dir = joinpath(project_root, "test", "fcsexamples")
+if !isdir(testdata_dir)
+    run(`git -C $(joinpath(project_root, "test")) clone https://github.com/tlnagy/fcsexamples.git --branch main --depth 1`)
+else
+    run(`git -C $testdata_dir fetch`)
+    # for reproducibility we should use hard reset
+    run(`git -C $testdata_dir reset --hard origin/main`)
+    run(`git -C $testdata_dir pull`)
+end
+
 @testset "FCSFiles test suite" begin
-
-    # test loading an FCS 2.0 file
-    @testset "Loading an FCS 2.0 file" begin
-        # download the FCS 2.0 file
-        cwd = pwd()
-        cd(cwd*"/testdata")
-        @info "Downloading FCS 2.0 file ..."
-        io = open("testFCS2.fcs", "w")
-        r = HTTP.request("GET", "https://flowrepository.org/experiments/4/fcs_files/326/download", response_stream=io)
-        close(io)
-        cd(cwd)
-        @info "Done."
-
-        # load the FCS 2.0 file
-        @test_throws ErrorException @test_warn "FSC2.0 files are not guaranteed to work" flowrun = load("testdata/testFCS2.fcs")
-
-        # cleanup
-        rm("testdata/testFCS2.fcs", force=true)
-        @info "FCS 2.0 file removed"
-    end
-
     # test the size of the file
     @testset "SSC-A size" begin
-        flowrun = load("testdata/BD-FACS-Aria-II.fcs")
-
+	flowrun = load(joinpath(testdata_dir, "BD-FACS-Aria-II.fcs"))
         @test length(flowrun["SSC-A"]) == 100000
     end
 
     # test the loading of a large FCS file
     @testset "Loading of large FCS file" begin
-        # download the large FCS file
-        cwd = pwd()
-        cd(cwd*"/testdata")
-        @info "Downloading large FCS file ..."
-        io = open("testLargeFile.fcs", "w")
-        r = HTTP.request("GET", "https://flowrepository.org/experiments/1177/fcs_files/113151/download", response_stream=io)
-        close(io)
-        cd(cwd)
-        @info "Done."
-
         # load the large file
-        flowrun = load("testdata/testLargeFile.fcs")
+	flowrun = load(joinpath(testdata_dir, "Day 3.fcs"))
         @test length(flowrun.data) == 50
         @test length(flowrun.params) == 268
-
-        # cleanup
-        rm("testdata/testLargeFile.fcs", force=true)
-        @info "Large file removed"
     end
 end


### PR DESCRIPTION
Having the datasets in their own repo fixes the problems with flowrepo restricting access and having them inflate the size of this repo too much