### PR TITLE
Better reading of Int data types

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -106,14 +106,15 @@ function parse_data(io,
         error("Only float and integer data types are implemented for now, the required .fcs file is using another number encoding.")
     end
 
-    flat_data = Array{dtype}(undef, (end_data - start_data + 1) ÷ 4)
-
+    
     # Use the regular io if float and allow any endian type.
     # If the io buffer is an integer array, read in the data in flat format and use ltoh ans this is what is defined by the system.
     if text_mappings["\$DATATYPE"] != "I"
+        flat_data = Array{dtype}(undef, (end_data - start_data + 1) ÷ 4)
         read!(io, flat_data)
         endian_func = get_endian_func(text_mappings)
     else
+        flat_data = Array{dtype}(undef, length(buf2))
         read!(io_buffer, flat_data)
         endian_func=ltoh # System defined 
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -90,3 +90,8 @@ function get_endian_func(text_mappings::Dict{String, String})
 
 
 end
+
+function get_int_size(text_mappings::Dict{String, String})
+    int_map=Dict(i=>text_mappings[i] for i in filter(s->occursin(r"P.?B", s),keys(text_mappings)))
+    return int_map
+end


### PR DESCRIPTION
Fixes part of issue #4 by allowing breaking down the iostream into UInt8 and then bit shifting this to represent the correct value as a UInt32, it also allows double floats (Float64) to be read in. The current fix passes all tests relevant to the changes. Tests not passed are the deprecation warnings for data and param fields. 

The only thing this doesn't fix is for oddly sized ints e.g. Int10 - this would need a bit mask. 