### PR TITLE
Fix dependency warning on Base.show

### DIFF
--- a/src/type.jl
+++ b/src/type.jl
@@ -4,12 +4,12 @@ struct FlowSample{T<:Number, I<:AbstractVector{Int}}
 end
 
 const opt_params = [
-("Machine", "\$CYT"),
-("Begin Time", "\$BTIM"),
-("End Time", "\$ETIM"),
-("Date", "\$DATE"),
-("File", "\$FIL"),
-("Volume run", "\$VOL")
+("Machine", :cyt),
+("Begin Time", :btim),
+("End Time", :etim),
+("Date", :date),
+("File", :fil),
+("Volume run", :vol)
 ]
 
 
@@ -18,16 +18,16 @@ function Base.show(io::IO, f::FlowSample)
     print(io, typeof(f))
 
     for pair in opt_params
-        if haskey(f.params, pair[2])
-            print(io, "\n", spacing, "$(pair[1]): $(f.params[pair[2]])")
+        if hasproperty(f, pair[2])
+            print(io, "\n", spacing, "$(pair[1]): $(getproperty(f, pair[2]))")
         end
     end
     print(io, "\n", spacing, "Axes:")
-    n_params = parse(Int, f.params["\$PAR"])
+    n_params = parse(Int, f.par)
     for i in 1:n_params
-        print(io, "\n", spacing, spacing, "$(f.params["\$P$(i)N"])")
-        if haskey(f.params, "\$P$(i)S")
-            print(io, " ($(f.params["\$P$(i)N"]))")
+        print(io, "\n", spacing, spacing, "$(getproperty(f, Symbol("p$(i)n")))")
+        if hasproperty(f, Symbol("p$(i)s"))
+            print(io, " ($(getproperty(f, Symbol("p$(i)n"))))")
         end
     end
 end

--- a/src/type.jl
+++ b/src/type.jl
@@ -27,7 +27,7 @@ function Base.show(io::IO, f::FlowSample)
     for i in 1:n_params
         print(io, "\n", spacing, spacing, "$(getproperty(f, Symbol("p$(i)n")))")
         if hasproperty(f, Symbol("p$(i)s"))
-            print(io, " ($(getproperty(f, Symbol("p$(i)n"))))")
+            print(io, " ($(getproperty(f, Symbol("p$(i)s"))))")
         end
     end
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using FCSFiles
 using FileIO
 using Test
+using Logging
 
 project_root = dirname(dirname(@__FILE__))
 testdata_dir = joinpath(project_root, "test", "fcsexamples")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -175,6 +175,17 @@ end
         @test_logs (:warn, msg) flowrun.data
     end
 
+    @testset "show doesn't throw deprecation warning" begin
+        fn = joinpath(testdata_dir, "BD-FACS-Aria-II.fcs")
+        flowrun = load(fn)
+
+        # Dummy IO to avoid printing to console
+        io = IOBuffer()
+
+        # Check that no warnings are raised when calling @show
+        @test_logs min_level = Logging.Warn Base.show(io, flowrun)
+    end
+
     @testset "`param_lookup` for different versions of the param" begin
         fn = joinpath(testdata_dir, "BD-FACS-Aria-II.fcs")
         flowrun = load(fn)


### PR DESCRIPTION
fixes #18 
also found a bug in the show code as it repeats the same name twice, uses p$(i)n twice rather than once with p$(i)n and then with p$(i)s if available