### PR TITLE
fix double delimiters bug

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -32,17 +32,17 @@ function grab_word(iter, state, delimiter::Char)
     while iter_result !== nothing
         i, state = iter_result
 
-        # only add character if the current and previous are both
-        # delimiters (i.e. escaped) or neither are
         if i == delimiter
+            # check for a double delimiter
             next_iter_result = iterate(iter, state)
             if !isnothing(next_iter_result) && next_iter_result[1] == delimiter
-                # add one delimiter to the word
+                # double delimiter so:
+                # - add one delimiter to the word,
+                # - advance the state
                 push!(word, i)
-                # double delimiter so jump ahead
                 state = next_iter_result[2]
             else
-                break
+                break # single delimiter so terminate
             end
         else
             push!(word, i)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,24 +28,29 @@ and the state of the iterator.
 """
 function grab_word(iter, state, delimiter::Char)
     word = Char[]
-    prev = ' '
     iter_result = iterate(iter, state)
     while iter_result !== nothing
         i, state = iter_result
 
         # only add character if the current and previous are both
         # delimiters (i.e. escaped) or neither are
-        if !xor((prev == delimiter), (i == delimiter))
-            push!(word, i)
-            prev = i
+        if i == delimiter
+            next_iter_result = iterate(iter, state)
+            if !isnothing(next_iter_result) && next_iter_result[1] == delimiter
+                # add one delimiter to the word
+                push!(word, i)
+                # double delimiter so jump ahead
+                state = next_iter_result[2]
+            else
+                break
+            end
         else
-            break
+            push!(word, i)
         end
         iter_result = iterate(iter, state)
     end
     join(word), state
 end
-
 
 """
     verify_text(text_mappings) -> Void

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -231,4 +231,13 @@ end
         @test :params in propertynames(flowrun, true)
         @test :data in propertynames(flowrun, true)
     end
+
+    @testset "Double delimited files" begin
+        # test that we can read and parse files with double delimiters
+        fn = joinpath(testdata_dir, "Attune NxT - A1.fcs")
+        flowrun = load(fn)
+
+        @test hasproperty(flowrun, :p11f)
+        @test flowrun.p11f == "488/10"
+    end
 end


### PR DESCRIPTION
This PR applies the fix in #20 to ensure double delimiters are correctly accounted for when parsing the fcs file (don't terminate the word and are recorded as a single delimiter)

If you want a test for this, feel free to add the file I linked in #20 to the fcsexamples repo and I'll add a test here